### PR TITLE
Fix the duration height selector and passing a string to numerical style inputs

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -8,6 +8,7 @@ const Example = class extends React.Component {
   render() {
     return (
       <div className='Content'>
+
         <div className='FixedDemo-spacer'>
           <div className='FixedDemo-wrapper'>
             <Plx
@@ -101,6 +102,31 @@ const Example = class extends React.Component {
           using Plx&apos;s animation state classes.
           (In this case <code>::after</code> element is used.)
         </p>
+        <hr className='margin-y-50' />
+        <div className=''>
+          <p>
+            Manipulate Background Position
+          </p>
+        </div>
+        <Plx
+          className='bgDemo'
+          style={ {
+            backgroundImage: `url(${ keenImage })`,
+            height: 150,
+          } }
+          parallaxData={ [
+            {
+              start: '.title',
+              duration: 'height',
+              name: 'bgdemo',
+              properties: [{
+                startValue: 0,
+                endValue: 300,
+                property: 'backgroundPositionX',
+              }],
+            },
+          ] }
+        />
         <hr className='margin-y-50' />
         <div className=''>
           <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,7 @@
       <a href="https://github.com/Stanko/react-plx">GitHub</a>.
     </p>
 
-    <h3>Demo</h3>
+    <h3 class="title">Demo</h3>
 
     <p>
       Multiple effects, with three different segments.

--- a/source/Plx.js
+++ b/source/Plx.js
@@ -310,7 +310,7 @@ export default class Plx extends Component {
       value += min;
     }
 
-    return value.toFixed(2);
+    return parseFloat(value.toFixed(2));
   }
 
   handleResize() {

--- a/source/Plx.js
+++ b/source/Plx.js
@@ -395,14 +395,14 @@ export default class Plx extends Component {
 
         startPosition = maxScroll * percentageValue;
       } else if (typeof start === 'string') {
-        element = document.querySelector(start);
+        var startElement = document.querySelector(start);
 
-        if (!element) {
+        if (!startElement) {
           console.log(`Plx, ERROR: start selector matches no elements: "${ start }"`); // eslint-disable-line no-console
           return;
         }
 
-        startPosition = this.getElementTop(element);
+        startPosition = this.getElementTop(startElement);
       }
 
       startPosition += scrollOffset;


### PR DESCRIPTION
Fixes the following

- duration height selector was measuring the start element when a start selector is used
- strings provided to numerical style inputs do not convert to px units in React 16 (15.6 logs deprecation warning)
