### PR TITLE
Readme: Make it clearer that it needs an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,21 @@ import Plx from 'react-plx';
 
 class Example extends Component {
   render() {
+    const parallaxData = [{
+      start: 0,
+      end: '100vh',
+      properties: [
+        {
+          startValue: 1,
+          endValue: 2,
+          property: 'scale'
+        }
+      ]
+    }] // An array of parallax effects to be applied - see below for details
     return (
       <Plx
         className='MyAwesomeParallax'
-        parallaxData={ ... } // your parallax effects, see beneath
+        parallaxData={parallaxData}
       >
         /* Your content */
       </Plx>


### PR DESCRIPTION
Thanks for this library! 

I had a gotcha where I was passing an object in instead of an array and couldn't work out what I was doing wrong.

I've suggested an update to the Readme to make that clearer. I ended up delving into the source code to understand what was going on and this could save others similar issues.