### PR TITLE
Feature: basic start and end callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ Read more about how it works in [this blog post](https://muffinman.io/plx-react-
 
   Main data, describes parallax segments.
 
+* **onPlxStart** function
+
+  If set, the Plx component will call this function each time the animation state changes to active. (refer to [animation state CSS classes](#user-content-animation-state-css-classes))
+
+* **onPlxEnd** function
+
+  If set, the Plx component will call this function each time the animation state changes from active to another state. (refer to [animation state CSS classes](#user-content-animation-state-css-classes))
+
 Any other props will be passed to the component (for example this is useful for `aria-*` props).
 
 ### parallaxData

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -42,6 +42,10 @@ const Example = class extends React.Component {
             tagName='h1'
             className='Examples'
             parallaxData={ titleData }
+            // eslint-disable-next-line no-console
+            onPlxStart={ () => console.log('Example text Plx started!') }
+            // eslint-disable-next-line no-console
+            onPlxEnd={ () => console.log('Example text Plx ended!') }
           >
             Examples
           </Plx>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plx",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/source/Plx.js
+++ b/source/Plx.js
@@ -171,8 +171,6 @@ const PROPS_TO_OMIT = [
   'onPlxEnd',
 ];
 
-const emptyFunction = () => {};
-
 // Get element's top offset
 function getElementTop(el) {
   let top = 0;
@@ -735,7 +733,8 @@ export default class Plx extends Component {
     };
 
     // Skipping type checking as PropTypes will give a warning if the props aren't functions
-    this.callbacksEnabled = this.props.onPlxStart !== emptyFunction || this.props.onPlxEnd !== emptyFunction;
+    this.plxStartEnabled = this.props.onPlxStart !== null;
+    this.plxEndEnabled = this.props.onPlxEnd !== null;
   }
 
   componentDidMount() {
@@ -754,11 +753,10 @@ export default class Plx extends Component {
     if (prevProps !== this.props) {
       this.update();
     }
-    if (this.callbacksEnabled && prevState.plxStateClasses !== this.state.plxStateClasses) {
-      if (!wasActive && isActive) {
+    if ((this.plxStartEnabled || this.plxEndEnabled) && prevState.plxStateClasses !== this.state.plxStateClasses) {
+      if (this.plxStartEnabled && !wasActive && isActive) {
         this.props.onPlxStart();
-      }
-      if (wasActive && !isActive) {
+      } else if (this.plxEndEnabled && wasActive && !isActive) {
         this.props.onPlxEnd();
       }
     }
@@ -922,6 +920,6 @@ Plx.defaultProps = {
   parallaxData: [],
   style: {},
   tagName: 'div',
-  onPlxStart: emptyFunction,
-  onPlxEnd: emptyFunction,
+  onPlxStart: null,
+  onPlxEnd: null,
 };


### PR DESCRIPTION
This PR adds two props, onPlxStart and onPlxEnd.

This might be helpful in certain cases and doesn't hurt the library by increasing any complexity. I've pretty much just added a decorator to already computed values to enable this feature. It behaves as it previously did if we have neither of the aforementioned new props specified to the component.

@Stanko Let me know what you think!