### PR TITLE
[fix] Fix some performance bottlenecks

### DIFF
--- a/source/Plx.js
+++ b/source/Plx.js
@@ -520,7 +520,6 @@ function getNewState(scrollPosition, props, state, element) {
   } = props;
   const {
     showElement,
-    plxStyle,
     plxStateClasses,
   } = state;
 
@@ -559,13 +558,8 @@ function getNewState(scrollPosition, props, state, element) {
   const segments = [];
   let isInSegment = false;
   let lastSegmentScrolledBy = null;
-  const maxScroll = Math.max(
-    document.body.scrollHeight,
-    // document.body.offsetHeight,
-    // document.documentElement.clientHeight,
-    document.documentElement.scrollHeight,
-    // document.documentElement.offsetHeight
-  ) - window.innerHeight;
+  const bodyHeight = document.documentElement.scrollHeight || document.body.scrollHeight;
+  const maxScroll = bodyHeight - window.innerHeight;
 
   for (let i = 0; i < parallaxData.length; i++) {
     const {
@@ -698,7 +692,7 @@ function getNewState(scrollPosition, props, state, element) {
   newStyle.OFilter = newStyle.filter;
   newStyle.msFilter = newStyle.filter;
 
-  newState.plxStyle = newStyle
+  newState.plxStyle = newStyle;
 
   // Adding state class
   const newPlxStateClasses = getClasses(lastSegmentScrolledBy, isInSegment, parallaxData);

--- a/source/Plx.js
+++ b/source/Plx.js
@@ -159,7 +159,7 @@ const FILTER_PROPERTIES = [
 ];
 
 // Props to be removed from passing directly to the component element
-const PROPS_TO_OMIT = [
+const PROPS_TO_OMIT = new Set([
   'animateWhenNotInViewport',
   'children',
   'className',
@@ -169,7 +169,7 @@ const PROPS_TO_OMIT = [
   'tagName',
   'onPlxStart',
   'onPlxEnd',
-];
+]);
 
 // Get element's top offset
 function getElementTop(el) {
@@ -384,7 +384,7 @@ function parallax(scrollPosition, start, duration, startValue, endValue, easing)
     value += min;
   }
 
-  return parseFloat(value.toFixed(3));
+  return Math.floor(value * 1000) / 1000;
 }
 
 // Calculates current value for color parallax
@@ -501,7 +501,7 @@ function omit(object, keysToOmit) {
   const result = {};
 
   Object.keys(object).forEach(key => {
-    if (keysToOmit.indexOf(key) === -1) {
+    if (!keysToOmit.has(key)) {
       result[key] = object[key];
     }
   });
@@ -561,10 +561,10 @@ function getNewState(scrollPosition, props, state, element) {
   let lastSegmentScrolledBy = null;
   const maxScroll = Math.max(
     document.body.scrollHeight,
-    document.body.offsetHeight,
-    document.documentElement.clientHeight,
+    // document.body.offsetHeight,
+    // document.documentElement.clientHeight,
     document.documentElement.scrollHeight,
-    document.documentElement.offsetHeight
+    // document.documentElement.offsetHeight
   ) - window.innerHeight;
 
   for (let i = 0; i < parallaxData.length; i++) {
@@ -698,10 +698,7 @@ function getNewState(scrollPosition, props, state, element) {
   newStyle.OFilter = newStyle.filter;
   newStyle.msFilter = newStyle.filter;
 
-  // "Stupid" check if style should be updated
-  if (JSON.stringify(plxStyle) !== JSON.stringify(newStyle)) {
-    newState.plxStyle = newStyle;
-  }
+  newState.plxStyle = newStyle
 
   // Adding state class
   const newPlxStateClasses = getClasses(lastSegmentScrolledBy, isInSegment, parallaxData);


### PR DESCRIPTION
Fix some bottlenecks according to profiling in Chrome. Calculation time per frame is reduced by nearly 20ms, improve FPS from <40fps to 60fps in my case.

1. Refactor `omit` function using Set instead of array to improve lookup performance
2. Rewrite the algorithm of rounding to 3 decimal places replacing converting from float to string then to float again, which is quite expensive
3. **[Open to discuss]** Only compare the scrollHeights of two element when use `Math.max`, because in my personal understanding, the scrollHeight is always equal to or greater than the clientHeight or offsetHeight. This comsumes several milliseconds.

I am not so familiar with Web dev and CSS things, so I am not 100% sure about the 3rd point. You can argue that this does not always hold water and remove these three lines' comment, although it works fine for me so far.

BTW I crafted a declaration file of Typescript for myself. I am happy to share it if knowing how I am supposed to do. But it has a little flaw that I have not figured out the proper way to assign tag type according to the tagName string in props (or I did but it was too lengthy to please me to get it done, and I chose to use forced type conversion as a workaround).