### PR TITLE
Interpolate numbers in CSSValueString

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -58,7 +58,7 @@ type EasingNames =
 
 type Easing = EasingNames | [number, number, number, number] | ((t: number) => number);
 
-type CSSValueString = `{number}px` | `{number}%` | `{number}vh`;
+type CSSValueString = `${number}px` | `${number}%` | `${number}vh`;
 
 type StartEnd = CSSValueString | "self" | string | number | HTMLElement;
 


### PR DESCRIPTION
Update CSSValueString to use interpolation in the string literals. [Docs](https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html)

The current version will not allow any string values other than the exact matches such as `startOffset: '{number}vh'`. Writing e.g. an expected value such as `startOffset: '100vh'` will result in the following error:
![CSSValueString](https://user-images.githubusercontent.com/14319313/234271545-354b7ebb-2f6b-413e-831f-520be699e676.png)
